### PR TITLE
feat: add opal validation job

### DIFF
--- a/.github/actions/terraform-observe/opal-validation/action.yaml
+++ b/.github/actions/terraform-observe/opal-validation/action.yaml
@@ -1,0 +1,71 @@
+name: 'OPAL validation'
+description: 'run tf apply and destroy to validate opal'
+inputs:
+  observe-customer-id:
+    description: "customer id for test observe instance"
+    required: true
+  observe-domain:
+    description: "observeinc.com or observe-staging.com"
+    required: true
+  observe-user-handle: 
+    description: "observe user to create test assets"
+    required: true
+  observe-user-pswd:
+    description: "password for user to create test assets"
+    required: true
+    
+runs:
+  using: "composite"
+  steps:
+
+    - id: install-terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - id: get-github-repo-name
+      run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
+      shell: bash
+
+    - id: checkout-commit
+      uses: actions/checkout@v2
+
+    - id: build-tf-files
+      run: |
+        cd ..  
+        cp ${{ github.action_path }}/main.tf.original ./
+        cp ${{ github.action_path }}/provider.tf ./
+        cp ${{ github.action_path }}/versions.tf ./
+        cp ${{ github.action_path }}/parse_tf_vars.sh ./
+        sed -i.bak "s/%%COMMMIT%%/${{ github.sha }}/g" ./main.tf.original
+        sed -i.bak "s/%%REPOSITORY%%/${{ env.REPOSITORY_NAME }}/g" ./main.tf.original
+        sed -i.bak "s/%%OBSERVE_CUSTOMER_ID%%/${{ inputs.observe-customer-id }}/g" ./provider.tf
+        sed -i.bak "s/%%OBSERVE_DOMAIN%%/${{ inputs.observe-domain }}/g" ./provider.tf
+        sed -i.bak "s/%%OBSERVE_USER_HANDLE%%/${{ inputs.observe-user-handle }}/g" ./provider.tf
+        cp ./provider.tf ./provider.tf.bak
+        perl -pe "s/%%OBSERVE_USER_PSWD%%/${{ inputs.observe-user-pswd }}/g" provider.tf.bak > provider.tf
+        bash parse_tf_vars.sh ${{ env.REPOSITORY_NAME }}/variables.tf
+      shell: bash
+
+    - id: terraform-init
+      run: |
+        cd ..
+        terraform init
+      shell: bash
+
+    - id: terraform-plan
+      run: |
+        cd ..
+        terraform plan -no-color
+      shell: bash
+
+    - id: terraform-apply
+      run: |
+        cd ..
+        terraform apply -auto-approve -input=false
+      shell: bash
+
+    - id: terraform-destroy
+      run: |
+        cd ..
+        terraform destroy -auto-approve -input=false
+      shell: bash
+      if: always()

--- a/.github/actions/terraform-observe/opal-validation/main.tf.original
+++ b/.github/actions/terraform-observe/opal-validation/main.tf.original
@@ -1,0 +1,20 @@
+data "observe_workspace" "default" {
+  name = "Default"
+}
+
+module "test_defaults" {
+  source              = "./%%REPOSITORY%%"
+  workspace           = data.observe_workspace.default
+  observation_dataset = "test"
+  name_format         = "tf_test_defaults-%%COMMMIT%%/%s"
+}
+
+module "test_non_defaults" {
+  source              = "./%%REPOSITORY%%"
+  workspace           = data.observe_workspace.default
+  observation_dataset = "test"
+  name_format         = "tf_test_non_defaults-%%COMMMIT%%/%s"
+
+%%CUSTOM_VARIABLES%%
+
+}

--- a/.github/actions/terraform-observe/opal-validation/parse_tf_vars.sh
+++ b/.github/actions/terraform-observe/opal-validation/parse_tf_vars.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+input="$(cat "$1")"
+
+spaceless="${input//[$'\t\r\n ']/}"
+
+var_configs=''
+
+IFS=' ' read -r -a var_array <<< "${spaceless//'variable"'/ }"
+for variable in "${var_array[@]}"
+do 
+	var_name="${variable%%\"*}"
+	if [[ "$variable" == *"type=bool"* ]]; then
+		if [[ "$variable" == *"default=true"* ]]; then
+			var_configs="""${var_configs}
+  ${var_name} = false"""
+		elif [[ "$variable" == *"default=false"* ]]; then
+			var_configs="${var_configs}
+  ${var_name} = true"
+		elif [[ "$variable" == *"default=null"* ]]; then
+			var_configs="${var_configs}
+  ${var_name} = true"
+		fi
+	fi
+done
+
+perl -pe "s/%%CUSTOM_VARIABLES%%/${var_configs}/g" main.tf.original > main.tf

--- a/.github/actions/terraform-observe/opal-validation/provider.tf
+++ b/.github/actions/terraform-observe/opal-validation/provider.tf
@@ -1,0 +1,6 @@
+provider "observe" {
+  customer      = "%%OBSERVE_CUSTOMER_ID%%"
+  domain        = "%%OBSERVE_DOMAIN%%"
+  user_email    = "%%OBSERVE_USER_HANDLE%%"
+  user_password = "%%OBSERVE_USER_PSWD%%"
+}

--- a/.github/actions/terraform-observe/opal-validation/versions.tf
+++ b/.github/actions/terraform-observe/opal-validation/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    observe = {
+      source  = "terraform.observeinc.com/observeinc/observe"
+      version = "> 0.5.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -31,6 +31,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  opal-validation:
+    if: "!contains(fromJSON(inputs.skip).jobs, 'opal-validation')"
+    name: OPAL Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate OPAL with TF apply/destroy
+        uses: observeinc/.github/.github/actions/terraform-observe/opal-validation@main
+        with:
+          observe-customer-id: ${{ secrets.TERRAFORM_MODULES_OBSV_TEST_INST_ID }}
+          observe-domain: ${{ secrets.TERRAFORM_MODULES_OBSV_TEST_INST_DOMAIN }}
+          observe-user-handle: ${{ secrets.OBSV_USER_HANDLE }}
+          observe-user-pswd: ${{ secrets.OBSV_USER_PSWD }}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   ci-tests:
     if: "!contains(fromJSON(inputs.skip).jobs, 'ci-tests')"
     name: CI Tests Placeholder


### PR DESCRIPTION
## What does this PR do?

Adds a ci job to the `terraform-observe-*` ci tests that does OPAL validation and fails in the case that a new commit has an observe resource with bad OPAL (or otherwise fails to be applied). 

What it does in detail:

1. installs terraform
2. checks out the repo
3. builds a root terraform module for testing that sources to the repo
4. includes a `test_defaults` version of the module that has the bare minimum repos generally need to be used -- purpose: tests the default terraform values
5. includes a `test_non_defaults` version of the module by passing into the repo any boolean variables that exist, but with the opposite boolean value as their default (the idea is, include the opposite of the switches that are normally flipped one way or another) (this might break in some cases where non-default boolean values come with extra assumptions, e.g, i think we do this with the linuxhost repo, but that's... kind of not great anyway?)
6. runs terraform `init`, `plan`, `apply`, and `destroy` -- if anything fails along the way, that's bad and this test should fail. (uses a local terraform backend, and is set to always destroy regardless of success of other steps, so this should be a safe and clean way to run terraform apply tests without risk of clutter or competing terraform activity on the same observe instance).

## Motivation

automatic testing for valid OPAL in ci

## Limitations

This test assumes that there is some observe instance that is available for testing with. It only terraforms with a local backend (so no risk of competing terraform backends with multiple people applying on the same observe test instance), and always destroys even if errors occur in the apply step (so no risk of leaving clutter after failed applies).

This test introduces 4 new variables which are currently expected as secrets (but not all of them really make great sense as "secrets" per se 🤷 ). These include:

1. secrets.TERRAFORM_MODULES_OBSV_TEST_INST_ID
2. secrets.TERRAFORM_MODULES_OBSV_TEST_INST_DOMAIN
3. secrets.OBSV_USER_HANDLE
4. secrets.OBSV_USER_PSWD

I think these should basically all be org-wide secrets, since I expect we'll just want to use the same test account for them all. Later on, we may introduce another input for datastreams, which we may end up wanting to be repo-specific, but that's for a later time. 

## Testing

I've tested this check for both successes and failures on [this test repo branch](https://github.com/observeinc/terraform-observe-estib-test1/tree/slobsv/test-opal-val). 
- [Successful run](https://github.com/observeinc/terraform-observe-estib-test1/runs/6478648589?check_suite_focus=true)
- [Failed run](https://github.com/observeinc/terraform-observe-estib-test1/runs/6478683269?check_suite_focus=true) (with bad OPAL intentionally introduced)