### PR TITLE
feat: add ability to configure multiple opal validation tests

### DIFF
--- a/.github/actions/terraform-observe/terraform-test-apply/action.yaml
+++ b/.github/actions/terraform-observe/terraform-test-apply/action.yaml
@@ -1,0 +1,19 @@
+name: 'Terraform Test Apply'
+description: 'run tf apply and destroy to validate opal'
+
+runs:
+  using: "composite"
+  steps:
+
+    - id: install-terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - id: checkout-commit
+      uses: actions/checkout@v2
+
+    - id: run-test
+      shell: bash
+      run: make test ${{ env.TEST_DIRECTORY }}
+      env:
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+        GITHUB_SHA: ${{ github.sha }}

--- a/.github/scripts/terraform_tests.sh
+++ b/.github/scripts/terraform_tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+ERROR() { echo "::error::$*"; }
+INFO() { echo "::info::$*"; }
+DEBUG() { test -z "$VERBOSE" || echo "::debug::$*"; }
+
+if [[ -z $OBSERVE_CUSTOMER || -z $OBSERVE_DOMAIN || -z $OBSERVE_USER_EMAIL || -z $OBSERVE_USER_PASSWORD ]]; then
+  ERROR 'one or more OBSERVE_ environment variables are undefined'
+  exit 1
+fi
+
+REPO_DIRECTORY="${GITHUB_WORKSPACE:-$PWD}"
+
+if [[ $# -lt 1 ]]; then ERROR "usage error"; fi # Requires 1+ arguments
+DIR="$1"
+shift
+
+CMD="terraform -chdir=${REPO_DIRECTORY}/${DIR}"
+
+cleanup() {
+    if [ "$1" != "0" ]; then
+        ERROR "encountered an error, running terraform destroy for cleanup"
+        ERROR "exit code $1 occurred on line $2"
+    fi
+    ${CMD} destroy -auto-approve -input=false
+}
+
+${CMD} init
+trap 'cleanup $? $LINENO' EXIT
+${CMD} apply -auto-approve -input=false

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -31,6 +31,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  get-test-directories:
+    if: "!contains(fromJSON(inputs.skip).jobs, 'terraform-tests')"
+    name: Get Test Directories For OPAL Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build matrix
+        id: matrix
+        shell: bash
+        run: |
+          DIRS="$(find . -path "*.tests/*" ! -path "*.terraform*" -type d )"
+          [[ ${#DIRS} > 0 ]] && echo "::set-output name=directories::[\"${DIRS//$'\n'/\",\"}\"]" || echo "::set-output name=directories::[]"
+    outputs:
+      directories: ${{ steps.matrix.outputs.directories }}
+
+  terraform-test-apply:
+    needs: get-test-directories
+    if: ${{ needs.get-test-directories.outputs.directories != '[]' && needs.get-test-directories.outputs.directories != '' }}
+    name: OPAL Validation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: ${{ fromJson(needs.get-test-directories.outputs.directories) }}
+    steps:
+      - name: Validate OPAL with TF apply/destroy
+        uses: observeinc/.github/.github/actions/terraform-observe/terraform-test-apply@main
+        env: 
+          OBSERVE_CUSTOMER: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER }}
+          OBSERVE_DOMAIN: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_DOMAIN }}
+          OBSERVE_USER_EMAIL: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_EMAIL }}
+          OBSERVE_USER_PASSWORD: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_PASSWORD }}
+          TEST_DIRECTORY: ${{ matrix.directory }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   ci-tests:
     if: "!contains(fromJSON(inputs.skip).jobs, 'ci-tests')"
     name: CI Tests Placeholder


### PR DESCRIPTION
## What does this PR do?

(Note, this PR follows feedback from [a previously closed PR](https://github.com/observeinc/.github/pull/12); feel free to take a look at that for more context.)

Adds a ci job to the `terraform-observe-*` ci tests that does OPAL validation and fails in the case that a new commit has an observe resource with bad OPAL (or otherwise fails to be applied). 

What it does in detail:

1. installs terraform
2. checks out the repo
3. iterating through every `.tests/` subdirectory, creates a boilerplate `provider.tf`, and runs `terraform init`. If it does not find any `.tests/` subdirectories, it will fail with a message pointing to a readme for how to write tests. 
4. iterating through every `.tests/` subdirectory, runs `terraform apply` and `terraform plan`.  (applies with `-var name_format="tf_test_${{ github.sha }}$dir%s"` so that each workflow's observe-resources can be identified for each test, if for some unexpected reason they were not to be properly destroyed)
5. iterating through every `.tests/` subdirectory, runs `terraform destroy` (set to run `always()` so that this job doesn't leave orphaned resources in the observe account)

Reasons for keeping steps `3, 4, 5` separate and not joining them: 
- if destroy is not alone, then a failed apply will result in destroy not running (leaves orphaned resources in observe account)
- if init is not alone, then if plan or apply fail, a test `init` may not be run. If a `destroy` is attempted without an `init` then it fails, and subsequent `destroy` commands may not be run. 
- keeping everything separate like this allows us to add a new step after `4` where we run custom assertions, and we'll probably want that to be in its own step for easier troubleshooting when those fail

## Motivation

automatic testing for valid OPAL in ci

## Limitations / Assumptions 

**First**, This test assumes that there is some observe instance that is available for testing with. It only terraforms with a local backend (so no risk of competing terraform backends with multiple people applying on the same observe test instance), and always destroys even if errors occur in the apply step (so no risk of leaving clutter after failed applies).

**Second**, This test introduces 3 new variables which are currently expected as secrets. These include:

1. secrets.TERRAFORM_MODULES_OBSV_TEST_INST_ID
2. secrets.OBSV_USER_HANDLE
3. secrets.OBSV_USER_PSWD

I think these should basically all be org-wide secrets, since I expect we'll just want to use the same test account for them all. Later on, we may introduce another input for datastreams, which we may end up wanting to be repo-specific, but that's for a later time. 

**Third**, tests are created with subdirectories under `.tests/`, and each of these subdirectories contain the terraform files you would need to run a test scenario. For example, you can have a `.tests/default/` directory that would contain the bare minimum needed in its `main.tf`, `variables.tf`, etc. to apply the module with its default variable inputs. 

## Testing

I've tested this check for both successes and failures on [this test repo branch](https://github.com/observeinc/terraform-observe-estib-test1/tree/slobsv/test-opal-val). 
- [Successful run](https://github.com/observeinc/terraform-observe-estib-test1/runs/6617337271?check_suite_focus=true)
- [Failed run](https://github.com/observeinc/terraform-observe-estib-test1/runs/6617312139?check_suite_focus=true#step:2:658) (with bad OPAL intentionally introduced)