### PR TITLE
ci: only run pre-commmit update for template repo

### DIFF
--- a/.github/workflows/terraform-observe_pre-commit-autoupdate.yaml
+++ b/.github/workflows/terraform-observe_pre-commit-autoupdate.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   auto-update:
+    if: github.repository == 'observeinc/terraform-observe-example'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What does this PR do?

The pre-commit auto-update workflow updates the pre-commit tooling on a schedule and sometimes updates the `.pre-commit-config.yaml` with a version bump.

But the sync-to-template-repo workflow also runs on a schedule and updates the current repo's `.pre-commit-config.yaml` if the one from the template repo has changed. This can cause commit conflicts.

So this PR causes the pre-commit auto-update workflow to only be run for the template repo. All children repos will use the sync-to-template-repo workflow to get the updates to `.pre-commit-config.yaml`

## Testing

I pointed a child repo to use this branch and it had the intended results (skipped the pre-commit auto-update workflow) ([reference here](https://github.com/observeinc/terraform-observe-estib-test2/actions/runs/2417374038))