### PR TITLE
feat: add scripts to sync-from-template-repo

### DIFF
--- a/.github/workflows/terraform-observe_sync-from-template-repo.yaml
+++ b/.github/workflows/terraform-observe_sync-from-template-repo.yaml
@@ -89,20 +89,18 @@ jobs:
         run: |
           _files="$(
             find ${{ env.REPO_TEMPLATE }} \
-            -path "*/.github/*" \
-            ! -path "*/.github/workflows/*" \
+            -path "./.github/*" \
+            ! -path "./.github/workflows/*" \
             -type f \
             -print &&
             find ${{ env.REPO_TEMPLATE }} \
-            -name "Makefile" \
+            -path "./scripts/*" \
             -type f \
             -print &&
-            find ${{ env.REPO_TEMPLATE }} \
-            -name ".pre-commit-config.yaml" \
-            -type f \
-            -print &&
-            find ${{ env.REPO_TEMPLATE }} \
-            -name "LICENSE" \
+            find ${{ env.REPO_TEMPLATE }} \( \
+            -name "Makefile" -o \
+            -name ".pre-commit-config.yaml" -o \
+            -name "LICENSE" \) \
             -type f \
             -print)"
           for _file in ${_files}; do


### PR DESCRIPTION
## What does this PR do?

updates the `terraform-observe_sync-from-template-repo.yaml` workflow to...

1. be a bit simpler
2. also include any files in `scripts/*` in the content that gets synced from the template repo to children repos 

## Motivation

this is needed for the new terraform tests features we're adding

## Limitations

This workflow is pretty messy (started as more of a POC). We should probably clean it up someday. 

## Testing

I've tested the changed `find` command locally and it works nicely. Gives me...
- all files under `.github/` excepting `.github/workflows/` (which workflows cannot update or you get an error)
- all files under `scripts/`
- all files matching the name `Makefile`, `.pre-commit-config.yaml`, or `LICENSE`