### PR TITLE
fix: add directory files back to sync

### DIFF
--- a/.github/workflows/terraform-observe_sync-from-template-repo.yaml
+++ b/.github/workflows/terraform-observe_sync-from-template-repo.yaml
@@ -89,12 +89,12 @@ jobs:
         run: |
           _files="$(
             find ${{ env.REPO_TEMPLATE }} \
-            -path "./.github/*" \
-            ! -path "./.github/workflows/*" \
+            -path "${{ env.REPO_TEMPLATE }}/.github/*" \
+            ! -path "${{ env.REPO_TEMPLATE }}/.github/workflows/*" \
             -type f \
             -print &&
             find ${{ env.REPO_TEMPLATE }} \
-            -path "./scripts/*" \
+            -path "${{ env.REPO_TEMPLATE }}/scripts/*" \
             -type f \
             -print &&
             find ${{ env.REPO_TEMPLATE }} \( \


### PR DESCRIPTION
## What does this PR do?

fixes the sync-from-template-repo workflow to search on the correct directory for "path" based searches (like `.github/*` and `.scripts/*` )

## Motivation

fix the sync workflow

## Testing

Tested with a test repo and you can now see the "path" based files are picked up by the sync ([reference](https://github.com/observeinc/terraform-observe-estib-test2/actions/runs/2431141734)), and [the PR it generated](https://github.com/observeinc/terraform-observe-estib-test2/pull/8/files) includes the script files