### PR TITLE
ci: update get-test-directories to use tftests

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -42,7 +42,7 @@ jobs:
         id: matrix
         shell: bash
         run: |
-          DIRS="$(find . -path "*.tests/*" ! -path "*.terraform*" -type d )"
+          DIRS="$(find . -path "*tftests/*" ! -path "*.terraform*" -type d )"
           [[ ${#DIRS} > 0 ]] && echo "::set-output name=directories::[\"${DIRS//$'\n'/\",\"}\"]" || echo "::set-output name=directories::[]"
     outputs:
       directories: ${{ steps.matrix.outputs.directories }}


### PR DESCRIPTION
## What does this PR do?

updates the find command for the get-test-directories job to look for tests in `tftest` rather than `.tests`

## Limitations

Would like to have it use the `make` command instead, but that was giving space-delimited directories in its results, not newline-delimited. Which wouldn't work well for if someone has directories that have spaces in them. 

## Testing

Worked as expected in a test branch [here](https://github.com/observeinc/terraform-observe-estib-test1/actions/runs/2436035810)