### PR TITLE
fix: Correct prerelease artifact versions

### DIFF
--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -8,6 +8,12 @@ on:
         required: true
       TERRAFORM_MODULES_PRERELEASE_SLACK_URL:
         required: false
+    inputs:
+      release-count:
+        required: false
+        type: string
+        description: Number of releases to preserve in changelog. Default is 0 (regenerates all).
+        default: '0'
 
 jobs:
   publish:
@@ -25,6 +31,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Prepare prerelease version
+        run: |
+          # We want to know the tag for the last release on this branch; if none can be found, just use the first commit in the repo
+          last_release_ref=$(git describe --tags --abbrev=0 2> /dev/null || git rev-list --max-parents=0 HEAD)
+          echo commits_since_last_tag=$(git rev-list ${last_release_ref}..HEAD --count) >> $GITHUB_ENV
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          git-push: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-on-empty: 'false'
+          skip-version-file: 'true'
+          release-count: ${{ inputs.release-count }}
       - name: Mirror in S3
         run: make s3
       - name: Prepare Slack notification
@@ -32,7 +52,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          echo version=$(git describe --tags --always | sed 's/^v//' ) >> $GITHUB_ENV
+          echo version=$(git describe --tags | sed 's/^v//')-${commits_since_last_tag}-g$(git rev-parse --short HEAD~1) >> $GITHUB_ENV
           echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
       - name: Notify Slack
         env:


### PR DESCRIPTION
There are two issues with the versions on our prerelease artifacts right now:

1. If there are no tags in the repo, we get an invalid version that just consists of the short git hash for the repo. This is an invalid semantic version and it causes issues with Terraform tooling like the CLI and Hashicorp's `go-version` library
2. The base version for our prerelease artifacts is the same as the version for the latest release. In other words, if we've just released `1.5.1`, then the next change after that will result in a prerelease artifact with a version starting with `1.5.1` and then followed by the usual `-g<git hash>`. Instead, the base version should be the _next_ version we'll release, not the last version we released; for the example, that'd be either `1.5.2`, `1.6.0`, or `2.0.0`, depending on what changes had been made since the last release.

This change addresses both and has been tested on the example and OpenWeather repos.