### PR TITLE
feat: Distinguish between official and unofficial prerelease versions, adhere correctly to semantic versioning for prereleases

### DIFF
--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -36,6 +36,13 @@ jobs:
           # We want to know the tag for the last release on this branch; if none can be found, just use the first commit in the repo
           last_release_ref=$(git describe --tags --abbrev=0 2> /dev/null || git rev-list --max-parents=0 HEAD)
           echo commits_since_last_tag=$(git rev-list ${last_release_ref}..HEAD --count) >> $GITHUB_ENV
+          if [[ "${GITHUB_REF_NAME}" = main ]] || [[ "${GITHUB_REF_NAME}" = master ]]; then
+            # If building off of the main branch, this is an "official" prerelease; we give that the "beta" prerelease segment
+            echo alphabeta=beta >> $GITHUB_ENV
+          else
+            # Otherwise, it's an unofficial prerelease; we give that the "alpha" prerelease segment
+            echo alphabeta=alpha >> $GITHUB_ENV
+          fi
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3
@@ -52,7 +59,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          echo version=$(git describe --tags | sed 's/^v//')-${commits_since_last_tag}-g$(git rev-parse --short HEAD~1) >> $GITHUB_ENV
+          echo version=$(git describe --tags | sed 's/^v//')-${commits_since_last_tag}.${alphabeta}+g$(git rev-parse --short HEAD~1) >> $GITHUB_ENV
           echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
       - name: Notify Slack
         env:


### PR DESCRIPTION
1. Semantic versioning requires that prerelease versions adhere to the format `major.minor.patch-prerelease+metadata`, where `+metadata` is optional and `prerelease` consists of one or more segments separated by dot (`.`). This change tweaks our prerelease versions to adhere to that format correctly. The git commit hash is moved to the metadata portion of the version as it cannot be compared to other git hashes in isolation (i.e., without referencing information not present in the version itself).
2. It might be useful to build prerelease artifacts off of non-main (or non-master) branches. In order to facilitate that without making it difficult to distinguish between those artifacts and ones built off of main branches, an additional prerelease segment is added that consists of `alpha` for versions built from non-main branches and `beta` for versions built from main branches. This segment comes after the "number of commits since last tag" field, which should help preserve ordering.

This was tested against the example repo, which produced a successful `alpha` release, and a slightly-tweaked variant that counted `alpha-releases-testing` as a "main" branch was tested against the example repo again to produce a successful `beta` release.