### PR TITLE
fix: Use correct prerelease version when publishing to S3

### DIFF
--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Prepare prerelease version
+      - name: Prepare prerelease version (pre-changelog)
         run: |
           # We want to know the tag for the last release on this branch; if none can be found, just use the first commit in the repo
           last_release_ref=$(git describe --tags --abbrev=0 2> /dev/null || git rev-list --max-parents=0 HEAD)
@@ -52,14 +52,16 @@ jobs:
           skip-on-empty: 'false'
           skip-version-file: 'true'
           release-count: ${{ inputs.release-count }}
+      - name: Prepare prerelease version (post-changelog)
+        run: |
+          echo version=$(git describe --tags | sed 's/^v//')-${commits_since_last_tag}.${alphabeta}+g$(git rev-parse --short HEAD~1) >> $GITHUB_ENV
       - name: Mirror in S3
-        run: make s3
+        run: make s3 TAG="v${version}"
       - name: Prepare Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          echo version=$(git describe --tags | sed 's/^v//')-${commits_since_last_tag}.${alphabeta}+g$(git rev-parse --short HEAD~1) >> $GITHUB_ENV
           echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
       - name: Notify Slack
         env:


### PR DESCRIPTION
Forgot to update the `make s3` invocation to use the correct version when publishing S3 artifacts. Verified against the example module by manually invoking its prerelease action and ensuring that the corresponding S3 artifact had the correct version component in its path.