### PR TITLE
ci: fix pre-commit auto-update permissions error

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## What does this PR do?

the `.github/workflows/pre-commit-autoupdate.yaml` workflow has been failing for the `terraform-observe-example` repo (the one repo we care to be running it successfully) because the workflow does not have sufficient permissions to run the `peter-evans/create-pull-request` action. This PR adds the permissions that [its documentation](https://github.com/peter-evans/create-pull-request#action-inputs) says we need. 

## Motivation

enable pre-commit-autoupdate.yaml again

## Testing

I did a test run of this branch's workflow and [it ran successfully](https://github.com/observeinc/terraform-observe-example/runs/7117730876?check_suite_focus=true)