### PR TITLE
feat: pin terraform v1-2-9 to avoid problems with 1-3-0

### DIFF
--- a/.github/actions/terraform-observe/terraform-test-apply/action.yaml
+++ b/.github/actions/terraform-observe/terraform-test-apply/action.yaml
@@ -7,6 +7,8 @@ runs:
 
     - id: install-terraform
       uses: hashicorp/setup-terraform@v1
+      with: 
+        terraform_version: 1.2.9
 
     - id: checkout-commit
       uses: actions/checkout@v2


### PR DESCRIPTION
Pins terraform version to v1.2.9 since as soon as we started using 1.3.0 we started hitting errors like [this one](https://github.com/observeinc/terraform-observe-aws/actions/runs/3099567915/jobs/5018859948#step:2:6638).

Joao opened an issue on this [here](https://github.com/hashicorp/terraform/issues/31838), for reference.  