### PR TITLE
terraform/account: run apply on any event on default branch

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -91,5 +91,5 @@ jobs:
         run: exit 1
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: terraform apply -auto-approve


### PR DESCRIPTION
For the "Terraform Account" workflow, supports being called from workflows that run on `workflow_dispatch`. Also avoids hardcoding the default branch name, which allows the workflow to support repositories with `master` or other branch names.