### PR TITLE
terraform: update `setup-terraform` action

### DIFF
--- a/.github/actions/terraform-observe/terraform-test-apply/action.yaml
+++ b/.github/actions/terraform-observe/terraform-test-apply/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
 
     - id: install-terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with: 
         terraform_version: 1.2.9
 

--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           directory: ${{ matrix.directory }}
       - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.minMax.outputs.minVersion }}
       - name: Install pre-commit dependencies
@@ -107,7 +107,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Install Terraform v${{ matrix.version }}
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.version }}
       - name: Install pre-commit dependencies

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.4
 

--- a/.github/workflows/tf-update-lock.yaml
+++ b/.github/workflows/tf-update-lock.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.4
 


### PR DESCRIPTION
v2.0.3 updates `@actions/core` to use environment files for outputs:

https://github.com/hashicorp/setup-terraform/releases/tag/v2.0.3

This fixes the following deprecation warning:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The breaking change in v2 is that Node 16 is used instead of Node 12, which is really not breaking except in exceptional cases (self-hosted runners).