### PR TITLE
dependabot: init

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - directory: /
+    open-pull-requests-limit: 10
+    package-ecosystem: github-actions
+    schedule: 
+      interval: weekly


### PR DESCRIPTION
Runs `dependabot` on this repository so that actions workflow updates like #30 are proposed automatically.