### PR TITLE
terraform: add plan to job summary

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan\n"
+            echo '# Terraform Plan'
             echo '```'
             echo "$PLAN"
             echo '```'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -60,10 +60,22 @@ jobs:
         run: terraform plan -no-color
         continue-on-error: true
 
-      - uses: actions/github-script@v6
+      - name: Add Plan to Job Summary
+        run: |
+          {
+            echo "# Terraform Plan\n"
+            echo '```hcl'
+            echo "$PLAN"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PLAN: "${{ steps.plan.outputs.stdout }}"
+
+      - name: Create Pull Request Comment
+        uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+          PLAN: "${{ steps.plan.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,8 +63,8 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan"
-            echo '```hcl'
+            echo "# Terraform Plan\n"
+            echo '```'
             echo "$PLAN"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
@@ -85,7 +85,7 @@ jobs:
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
             <details><summary>Show Plan</summary>
 
-            \`\`\`\`hcl\n
+            \`\`\`\`\n
             ${process.env.PLAN}
             \`\`\`\`
             </details>

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan\n"
+            echo "# Terraform Plan"
             echo '```hcl'
             echo "$PLAN"
             echo '```'


### PR DESCRIPTION
Adds the Terraform plan to the [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary). While adding comments on a PR is readily discoverable, it comes with a handful of disadvantages:

* Creates lots of clutter when pushing multiple times
* Length limit is low (~65 KB)

Actions [added](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) job summaries earlier this year to help accommodate human-readable output while addressing the issues above.

For now, this is relatively invisible unless you know how to navigate to the job summary page. The new step only runs on pull requests, strictly because `terraform plan` only runs on pull requests. In a future PR, if I can both write the plan to a file and get normal output, I'd want to write the plan to the job summary for all events, and then have `terraform apply` use the plan on runs on the default branch.

In an upcoming PR that will be based on this branch, I'll link to the job summary from the PR comment (in the `<summary>`) and omit the plan from the comment when its length exceeds 60 KB. 

For consistency I also made some small edits to the PR comment step:

* Added a `name`
* Removed `terraform` from the first line of the plan

https://observe.atlassian.net/browse/OB-12109