### PR TITLE
deps: update `aws-actions/configure-aws-credentials` to use Node.js v16

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
           aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}

--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -42,7 +42,7 @@ jobs:
       OBSERVE_CUSTOMER: 0
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
           aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}
@@ -98,7 +98,7 @@ jobs:
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
           aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}

--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
           aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
           aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -36,7 +36,7 @@ jobs:
         run: terraform fmt -check
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.sha }}


### PR DESCRIPTION
AWS is moving fairly slowly towards `v2` of this action. Node 12 is in its late stages of deprecation but they haven't made a major release that requires 16 yet. Instead, they're offering this alternate tag and dual-publishing.

https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning

There's still a `set-output` warning, reported here:

https://github.com/aws-actions/configure-aws-credentials/issues/601

Will submit a fix upstream for that.