### PR TITLE
terraform: omit plans that exceed comment length limit

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const MAX_PLAN_LENGTH = 6 // 60000 // Max comment length is 65536
+            const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
             const plan = '```\n' + process.env.PLAN + '\n```'
 
             const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
+            const MAX_PLAN_LENGTH = 6 // 60000 // Max comment length is 65536
             const plan = '```\n' + process.env.PLAN + '\n```'
 
             const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan\n"
+            echo '# Terraform Plan'
             echo '```'
             echo "$PLAN"
             echo '```'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -60,10 +60,22 @@ jobs:
         run: terraform plan -no-color
         continue-on-error: true
 
-      - uses: actions/github-script@v6
+      - name: Add Plan to Job Summary
+        run: |
+          {
+            echo "# Terraform Plan\n"
+            echo '```hcl'
+            echo "$PLAN"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PLAN: "${{ steps.plan.outputs.stdout }}"
+
+      - name: Create Pull Request Comment
+        uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+          PLAN: "${{ steps.plan.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,8 +63,8 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan"
-            echo '```hcl'
+            echo "# Terraform Plan\n"
+            echo '```'
             echo "$PLAN"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
@@ -85,7 +85,7 @@ jobs:
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
             <details><summary>Show Plan</summary>
 
-            \`\`\`\`hcl\n
+            \`\`\`\`\n
             ${process.env.PLAN}
             \`\`\`\`
             </details>

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Add Plan to Job Summary
         run: |
           {
-            echo "# Terraform Plan\n"
+            echo "# Terraform Plan"
             echo '```hcl'
             echo "$PLAN"
             echo '```'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -79,15 +79,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
+            const plan = '```\n' + process.env.PLAN + '\n```'
+
+            const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-            <details><summary>Show Plan</summary>
+            <details><summary>Show <a href="${workflowSummaryURL}">Plan</a></summary>
 
-            \`\`\`\`\n
-            ${process.env.PLAN}
-            \`\`\`\`
+            ${plan.length <= MAX_PLAN_LENGTH ? plan : `_The plan is too large to include in a comment, open the [workflow summary](${workflowSummaryURL}) to view it._`}
             </details>
 
             **Pusher**: @${{ github.actor }}, **Action**: \`${{ github.event_name }}\``;


### PR DESCRIPTION
* Adds a link to the job summary for the workflow run where the plan is included
* When the plan is too large for a comment, instead includes an italicized note that users can inspect the plan in the workflow summary, with a second link to the same place

https://observe.atlassian.net/browse/OB-12109