### PR TITLE
terraform: run PR validation jobs on PR events

### DIFF
--- a/.github/workflows/shared_commit-validation.yaml
+++ b/.github/workflows/shared_commit-validation.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   conventional-commits:
-    if: "!contains(fromJSON(inputs.skip).jobs, 'conventional-commits')"
+    if: "github.event_name == 'pull_request' && !contains(fromJSON(inputs.skip).jobs, 'conventional-commits')"
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +22,7 @@ jobs:
           wip: true
 
   single-commit:
-    if: "!contains(fromJSON(inputs.skip).jobs, 'single-commit')"
+    if: "github.event_name == 'pull_request' && !contains(fromJSON(inputs.skip).jobs, 'single-commit')"
     name: Ensure Single Commit 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Configures the Terraform commit validation jobs, which only apply to commits in pull requests, to only run when the event is `pull_request`. Called workflows inherit the event name of their caller.

Previously, calls to this workflow from any event other than `pull_request`, e.g., `workflow_dispatch`, would cause these jobs to fail, given that the actions called in their steps expect to run on a PR:

https://github.com/observeinc/terraform-observe-gitlab/actions/runs/4108000982