### PR TITLE
Accept `terraform-version` as optional workflow input

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         description: "example: {\"jobs\": [\"validate-pr-title\", \"single-commit\"]}"
+      terraform-version:
+        description: 'Terraform version'
+        required: false
+        type: string
+        default: '1.2.9'
 
 jobs:
   commit-validation:
@@ -43,7 +48,7 @@ jobs:
     steps:
       - uses: hashicorp/setup-terraform@v2
         with: 
-          terraform_version: 1.2.9
+          terraform_version: ${{ inputs.terraform-version }}
       - uses: actions/checkout@v2
       - name: make test
         run: make test "${{ matrix.directory }}"

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -18,7 +18,7 @@ on:
         type: string
 
 env:
-  TERRAFORM_VERSION: ${{ inputs.TERRAFORM_VERSION || var.TERRAFORM_VERSION || '1.2.4' }}
+  TERRAFORM_VERSION: ${{ inputs.TERRAFORM_VERSION || vars.TERRAFORM_VERSION || '1.2.4' }}
 
 jobs:
   terraform:

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   terraform:
-    name: 'Run terraform'
+    name: 'Run terraform' 
     runs-on: ubuntu-latest
     # Needed to interact with Github's OIDC token
     permissions:

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -14,7 +14,7 @@ on:
         required: true
     inputs:
       terraform-version:
-        description: 'Terraform version' 
+        description: 'Terraform version'
         required: false
         type: string
         default: '1.2.4'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -14,7 +14,7 @@ on:
         required: true
     inputs:
       terraform-version:
-        description: 'Terraform version'
+        description: 'Terraform version' 
         required: false
         type: string
         default: '1.2.4'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -12,6 +12,13 @@ on:
         required: true
       TF_BACKEND_S3_REGION:
         required: true
+    inputs:
+      TERRAFORM_VERSION:
+        required: false
+        type: string
+
+env:
+  TERRAFORM_VERSION: ${{ inputs.TERRAFORM_VERSION || var.TERRAFORM_VERSION || '1.2.4' }}
 
 jobs:
   terraform:
@@ -29,7 +36,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.4
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Terraform Format
         id: fmt

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -13,16 +13,15 @@ on:
       TF_BACKEND_S3_REGION:
         required: true
     inputs:
-      TERRAFORM_VERSION:
+      terraform-version:
+        description: 'Terraform version'
         required: false
         type: string
-
-env:
-  TERRAFORM_VERSION: ${{ inputs.TERRAFORM_VERSION || vars.TERRAFORM_VERSION || '1.2.4' }}
+        default: '1.2.4'
 
 jobs:
   terraform:
-    name: 'Run terraform' 
+    name: 'Run terraform'
     runs-on: ubuntu-latest
     # Needed to interact with Github's OIDC token
     permissions:
@@ -36,7 +35,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_version: ${{ inputs.terraform-version }}
 
       - name: Terraform Format
         id: fmt

--- a/.github/workflows/tf-update-lock.yaml
+++ b/.github/workflows/tf-update-lock.yaml
@@ -1,6 +1,12 @@
 name: Update Terraform Lockfile
 on:
   workflow_call:
+  inputs:
+      terraform-version:
+        description: 'Terraform version'
+        required: false
+        type: string
+        default: '1.2.4'
 
 jobs:
   terraform:
@@ -20,7 +26,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.4
+          terraform_version: ${{ inputs.terraform-version }}
 
       - name: Close Previous PR
         id: close_pr

--- a/.github/workflows/tf-update-lock.yaml
+++ b/.github/workflows/tf-update-lock.yaml
@@ -1,7 +1,7 @@
 name: Update Terraform Lockfile
 on:
   workflow_call:
-  inputs:
+    inputs:
       terraform-version:
         description: 'Terraform version'
         required: false


### PR DESCRIPTION
Allows jobs and users to customize the version of terraform that we use in Github Actions. Jobs can customize the terraform version through the `var` context. Users can customize the terraform version when they manually kick off a Github Actions job