### PR TITLE
Icon validation

### DIFF
--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -122,27 +122,3 @@ jobs:
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
         run: pre-commit run --color=always --show-diff-on-failure --all-files
-
-  # Validate App Icon URL is internal
-  validateAppIcon:
-    name: Validate App Icon
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check manifest.yaml exists
-        id: check_manifest
-        uses: andstor/file-existence-action@2.0.0
-        with:
-          files: "manifest.yaml"
-      - name: Get App Icon URL
-        id: get_icon_url
-        uses: mikefarah/yq@v4.31.1
-        if: steps.check_manifest.outputs.files_exists == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          cmd: yq '.iconUrl' manifest.yaml
-      - name: Validate App Icon URL
-        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
-        run: exit 1

--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -122,3 +122,27 @@ jobs:
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
         run: pre-commit run --color=always --show-diff-on-failure --all-files
+
+  # Validate App Icon URL is internal
+  validateAppIcon:
+    name: Validate App Icon
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check manifest.yaml exists
+        id: check_manifest
+        uses: andstor/file-existence-action@2.0.0
+        with:
+          files: "manifest.yaml"
+      - name: Get App Icon URL
+        id: get_icon_url
+        uses: mikefarah/yq@v4.31.1
+        if: steps.check_manifest.outputs.files_exists == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          cmd: yq '.iconUrl' manifest.yaml
+      - name: Validate App Icon URL
+        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+        run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') }}
+        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
         run: echo "App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Check manifest.yaml exists
         id: check_manifest
-        uses: andstor/file-existence-action@2.0.0
+        uses: andstor/file-existence-action@v2.0.0
         with:
           files: "manifest.yaml"
       - name: Get App Icon URL

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -83,6 +83,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cmd: yq '.iconUrl' manifest.yaml
-      # - name: Validate App Icon URL
-      #   if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
-      #   run: exit 1
+      - name: Validate App Icon URL
+        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+        run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -6,12 +6,12 @@ on:
       skip:
         required: false
         type: string
-        description: "example: {\"jobs\": [\"validate-pr-title\", \"single-commit\"]}"
+        description: 'example: {"jobs": ["validate-pr-title", "single-commit"]}'
       terraform-version:
-        description: 'Terraform version'
+        description: "Terraform version"
         required: false
         type: string
-        default: '1.2.9'
+        default: "1.2.9"
 
 jobs:
   commit-validation:
@@ -47,7 +47,7 @@ jobs:
         directory: ${{ fromJson(needs.get-test-directories.outputs.directories) }}
     steps:
       - uses: hashicorp/setup-terraform@v2
-        with: 
+        with:
           terraform_version: ${{ inputs.terraform-version }}
       - uses: actions/checkout@v3
       - name: make test
@@ -57,11 +57,11 @@ jobs:
           OBSERVE_DOMAIN: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_DOMAIN }}
           OBSERVE_USER_EMAIL: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_EMAIL }}
           OBSERVE_USER_PASSWORD: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_PASSWORD }}
-          
+
           GITHUB_WORKSPACE: ${{ github.workspace }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   # Validate App Icon URL is internal
   validateAppIcon:
     name: Validate App Icon
@@ -82,7 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cmd: yq '.iconUrl' manifest.yaml
-      - name: Validate App Icon URL
-        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
-        run: exit 1
-
+      # - name: Validate App Icon URL
+      #   if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+      #   run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+        if: ${{ !startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/') }}
         run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+        if: "!startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')"
         run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -61,3 +61,28 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  # Validate App Icon URL is internal
+  validateAppIcon:
+    name: Validate App Icon
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check manifest.yaml exists
+        id: check_manifest
+        uses: andstor/file-existence-action@2.0.0
+        with:
+          files: "manifest.yaml"
+      - name: Get App Icon URL
+        id: get_icon_url
+        uses: mikefarah/yq@v4.31.1
+        if: steps.check_manifest.outputs.files_exists == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          cmd: yq '.iconUrl' manifest.yaml
+      - name: Validate App Icon URL
+        if: ! startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
+        run: exit 1
+

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') }}
-        run: exit 1
+        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://twitter.com/') }}
+        run: echo "App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://twitter.com/') }}
+        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') }}
         run: echo "App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -69,6 +69,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v3
       - name: Check manifest.yaml exists
         id: check_manifest
         uses: andstor/file-existence-action@v2

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: ${{ !startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/') }}
+        if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') }}
         run: exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Check manifest.yaml exists
         id: check_manifest
-        uses: andstor/file-existence-action@v2.0.0
+        uses: andstor/file-existence-action@v2
         with:
           files: "manifest.yaml"
       - name: Get App Icon URL

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -84,5 +84,5 @@ jobs:
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
-        if: "!startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')"
+        if: startsWith(${{ steps.get_icon_url.outputs.result }}, 'https://assets.observeinc.com/')
         run: exit 1


### PR DESCRIPTION
(note: will be squashing commits when merging)

This new CI job will validate that the `iconUrl` attribute of the `manifest.yaml` file in our repositories (if the file exists) comes from the `assets.observeinc.com` domain. It will skip the check if the `manifest.yaml` file does not exist.