### PR TITLE
fix: validate-app-icon cleanup

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -83,4 +83,4 @@ jobs:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
         if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
-        run: echo "::error file=mainfest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1
+        run: echo "::error file=manifest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -83,4 +83,4 @@ jobs:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
         if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
-        run: echo "::error file=manifest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1
+        run: echo "::error file=manifest.yaml,title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Validate App Icon URL is internal
-  validateAppIcon:
+  validate-app-icon:
     name: Validate App Icon
     runs-on: ubuntu-latest
     permissions:
@@ -79,10 +79,8 @@ jobs:
         id: get_icon_url
         uses: mikefarah/yq@v4.31.1
         if: steps.check_manifest.outputs.files_exists == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
         if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
-        run: echo "App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1
+        run: echo "::warning file=mainfest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -83,4 +83,4 @@ jobs:
           cmd: yq '.iconUrl' manifest.yaml
       - name: Validate App Icon URL
         if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
-        run: echo "::warning file=mainfest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1
+        run: echo "::error file=mainfest.yaml, title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1


### PR DESCRIPTION
Addresses feedback from the [previous PR](https://github.com/observeinc/.github/pull/56):

* job name has been fixed to be in the proper style
* removes `env` from `get_icon_url` step left over from previous implementation
* utilizes GitHub annotations for error message