### PR TITLE
Add contributor guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+**Status:** Frozen
+
+This repository is "frozen" to major changes. Bug fixes and feature additions to existing workflows will be accepted, but breaking changes are strongly discouraged and new workflows should not be added.
+
+Moving forward, each workflow or group of tightly coupled workflows should be hosted in separate repositories. This enables:
+
+* Versioning with tags
+* Integration testing


### PR DESCRIPTION
Adds contributor guidelines, which are linked in the UI when opening PRs. They inform contributors that they can make changes to existing workflows stored here, but shouldn't be introducing breaking changes or new workflows.

Going forward, we should build new workflows in dedicated repositories. Work to split up this repository to enable easier maintenance including the ability to make breaking changes is tracked here:

https://observe.atlassian.net/browse/OB-16102