### PR TITLE
pre-commit: accept TFLint version as input

### DIFF
--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -2,6 +2,12 @@ name: Pre-Commit
 
 on:
   workflow_call:
+    inputs:
+      tflint-version:
+        required: false
+        type: string
+        default: v0.35.0
+        
     secrets:
       TERRAFORM_MODULES_ROLE_ARN:
         required: true
@@ -117,7 +123,7 @@ jobs:
       - uses: terraform-linters/setup-tflint@v3
         name: Setup TFLint
         with:
-          tflint_version: v0.35.0
+          tflint_version: ${{ inputs.tflint-version }}
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}


### PR DESCRIPTION
Defines `tflint-version` as an input to the callable workflow, with the default set to the currently hardcoded value. For existing callers, this is a noop. In general, we should avoid mixing parameters and logic. A caller might use this to:

* Pin an older version in case of module-specific incompatibilities
* Test a newer version