### PR TITLE
fix: iconUrl key is case insensitive

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: mikefarah/yq@v4.31.1
         if: steps.check_manifest.outputs.files_exists == 'true'
         with:
-          cmd: yq '.iconUrl' manifest.yaml
+          cmd: yq 'with_entries(.key |= downcase).iconurl' manifest.yaml
       - name: Validate App Icon URL
         if: ${{ !startsWith(steps.get_icon_url.outputs.result, 'https://assets.observeinc.com/') && steps.check_manifest.outputs.files_exists == 'true' }}
         run: echo "::error file=manifest.yaml,title=Invalid App Icon URL::App icon URLs must live in the 'assets.observeinc.com' domain" && exit 1


### PR DESCRIPTION
This PR makes the `yq` check for the value of `iconUrl` case insensitive. Tested locally.