### PR TITLE
release: add optional `push` input

### DIFF
--- a/.github/workflows/terraform_release.yaml
+++ b/.github/workflows/terraform_release.yaml
@@ -32,7 +32,7 @@ jobs:
           git-push: ${{ inputs.push }}
       - name: Create Release
         uses: actions/create-release@v1
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        if: ${{ inputs.push && steps.changelog.outputs.skipped == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/terraform_release.yaml
+++ b/.github/workflows/terraform_release.yaml
@@ -41,7 +41,7 @@ jobs:
           body: ${{ steps.changelog.outputs.clean_changelog }}
     outputs:
       tag: ${{ steps.changelog.outputs.tag }}
-      skipped: ${{ !inputs.push || steps.changelog.outputs.skipped == 'false' }}
+      pushed: ${{ inputs.push && steps.changelog.outputs.skipped == 'false' }}
   slack:
     runs-on: ubuntu-latest
     needs:
@@ -49,7 +49,7 @@ jobs:
 
     # jobs.<job_id>.if cannot access secrets directly, so if must be set at the step level to noop when the URL is unset
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    if: ${{ needs.release.outputs.skipped != 'false' }}
+    if: ${{ fromJson(needs.release.outputs.pushed) }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL }}
 

--- a/.github/workflows/terraform_release.yaml
+++ b/.github/workflows/terraform_release.yaml
@@ -46,15 +46,21 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release
-    if: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL != '' && needs.release.outputs.skipped != 'false' }}
+
+    # jobs.<job_id>.if cannot access secrets directly, so if must be set at the step level to noop when the URL is unset
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+    if: ${{ needs.release.outputs.skipped != 'false' }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL }}
+
     steps:
       - name: Prepare Slack notification
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
           echo version=$(echo "${{ needs.release.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
           echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-//') >> $GITHUB_ENV
       - name: Notify Slack
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |

--- a/.github/workflows/terraform_release.yaml
+++ b/.github/workflows/terraform_release.yaml
@@ -10,6 +10,11 @@ on:
         type: string
         description: Number of releases to preserve in changelog. Default is 0 (regenerates all).
         default: '0'
+      push:
+        required: false
+        type: boolean
+        description: Pushes the release commit and tag. Disable this to perform a dry-run. 
+        default: true
 
 jobs:
   bump:
@@ -24,6 +29,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-version-file: 'true'
           release-count: ${{ inputs.release-count }}
+          git-push: ${{ inputs.push }}
       - name: Create Release
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}

--- a/.github/workflows/terraform_release.yaml
+++ b/.github/workflows/terraform_release.yaml
@@ -17,7 +17,7 @@ on:
         default: true
 
 jobs:
-  bump:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -39,17 +39,22 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+    outputs:
+      tag: ${{ steps.changelog.outputs.tag }}
+      skipped: ${{ !inputs.push || steps.changelog.outputs.skipped == 'false' }}
+  slack:
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    if: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL != '' && needs.release.outputs.skipped != 'false' }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL }}
+    steps:
       - name: Prepare Slack notification
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL }}
-        if: ${{ env.SLACK_WEBHOOK_URL != '' && steps.changelog.outputs.skipped == 'false' }}
         run: |
-          echo version=$(echo "${{ steps.changelog.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
+          echo version=$(echo "${{ needs.release.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
           echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-//') >> $GITHUB_ENV
       - name: Notify Slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_RELEASE_SLACK_URL }}
-        if: ${{ env.SLACK_WEBHOOK_URL != '' && steps.changelog.outputs.skipped == 'false' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
@@ -59,5 +64,5 @@ jobs:
               "system": "observe",
               "version": "${{ env.version }}",
               "repo": "${{ github.repository }}",
-              "commit_link": "https://github.com/${{ github.repository }}/tree/${{ steps.changelog.outputs.tag }}"
+              "commit_link": "https://github.com/${{ github.repository }}/tree/${{ needs.release.outputs.tag }}"
             }


### PR DESCRIPTION
Adds an optional `push` input to the Terraform release workflow, enabled by default. By disabling this input, users can see how the new release would be generated without actually writing any results back to the repository. 

Tested via https://github.com/observeinc/terraform-aws-lambda/pull/55.