### PR TITLE
restore exact yq version

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -77,7 +77,7 @@ jobs:
           files: "manifest.yaml"
       - name: Get App Icon URL
         id: get_icon_url
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@v4.31.2
         if: steps.check_manifest.outputs.files_exists == 'true'
         with:
           cmd: yq 'with_entries(.key |= downcase).iconurl' manifest.yaml


### PR DESCRIPTION
Assumed this existed in #63, but `yq` doesn't publish semver tags for use in actions.

**The workflow is broken until this is merged.**

Please be aware of this when adding functionality, as it creates a large maintenance burden when we need to approve every single patch release for an active tool. Actions that do not offer semver tags should generally be avoided, particularly things like `yq` where an action is co-located in the main application repo.

Given that the uses of `yq` and especially `linkcheck` are trivial I'll look to replace the former with a different installation method and remove the latter in favor of a simpler tool (`curl` is plenty here) soon.