### PR TITLE
tf-account: pass plan via file

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -84,6 +84,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('fs')
             const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
             const plan = '```\n' + fs.readFileSync('${{ steps.plan.outputs.file }}', 'utf8') + '\n```'
 

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -64,9 +64,12 @@ jobs:
         id: plan
         if: github.event_name == 'pull_request'
         run: |
-          terraform plan -no-color -out=plan
-          terraform show -no-color plan > plan.out
-          echo "path=plan.out" >> $GITHUB_OUTPUT
+          path='plan'
+          txt_path='plan.txt'
+
+          terraform plan -no-color -out="$path"
+          terraform show -no-color "$path" > "$txt_path"
+          echo "path=${txt_path}" >> $GITHUB_OUTPUT
         continue-on-error: true
       
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -66,6 +66,7 @@ jobs:
         run: |
           terraform plan -no-color -out=plan
           terraform show -no-color plan > plan.out
+          echo "file=plan.out" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Add Plan to Job Summary
@@ -73,7 +74,7 @@ jobs:
           {
             echo '# Terraform Plan'
             echo '```'
-            cat plan.out
+            cat "${{ steps.plan.outputs.file }}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -84,7 +85,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
-            const plan = '```\n' + fs.readFileSync('plan.out', 'utf8') + '\n```'
+            const plan = '```\n' + fs.readFileSync('${{ steps.plan.outputs.file }}', 'utf8') + '\n```'
 
             const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -66,15 +66,22 @@ jobs:
         run: |
           terraform plan -no-color -out=plan
           terraform show -no-color plan > plan.out
-          echo "file=plan.out" >> $GITHUB_OUTPUT
+          echo "path=plan.out" >> $GITHUB_OUTPUT
         continue-on-error: true
+      
+      - uses: actions/upload-artifact@v3
+        if: steps.plan.outcome == 'success'
+        with:
+          name: plan
+          path: ${{ steps.plan.outputs.path }}
 
       - name: Add Plan to Job Summary
+        if: steps.plan.outcome == 'success'
         run: |
           {
             echo '# Terraform Plan'
             echo '```'
-            cat "${{ steps.plan.outputs.file }}"
+            cat "${{ steps.plan.outputs.path }}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -86,7 +93,7 @@ jobs:
           script: |
             const fs = require('fs')
             const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
-            const plan = '```\n' + fs.readFileSync('${{ steps.plan.outputs.file }}', 'utf8') + '\n```'
+            const plan = '```\n' + fs.readFileSync('${{ steps.plan.outputs.path }}', 'utf8') + '\n```'
 
             const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -63,7 +63,9 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
-        run: terraform plan -no-color
+        run: |
+          terraform plan -no-color -out=plan
+          terraform show -no-color plan > plan.out
         continue-on-error: true
 
       - name: Add Plan to Job Summary
@@ -71,22 +73,18 @@ jobs:
           {
             echo '# Terraform Plan'
             echo '```'
-            echo "$PLAN"
+            cat plan.out
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          PLAN: "${{ steps.plan.outputs.stdout }}"
 
       - name: Create Pull Request Comment
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
-        env:
-          PLAN: "${{ steps.plan.outputs.stdout }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const MAX_PLAN_LENGTH = 60000 // Max comment length is 65536
-            const plan = '```\n' + process.env.PLAN + '\n```'
+            const plan = '```\n' + fs.readFileSync('plan.out', 'utf8') + '\n```'
 
             const workflowSummaryURL = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 


### PR DESCRIPTION
Pass around the plan as a file. Fixes "Argument list too long" errors.

See discussion: https://github.com/actions/github-script/issues/266
Failing job: https://github.com/observeinc/tf-account-auditboard/actions/runs/4504586394/jobs/7929250161

Also uploads the plan as an artifact for easier access when it's so large that it doesn't fit in the job summary (several megabytes). This is still easier than trying to hunt it down via the log viewer, which tries to stream log lines and can be very slow for a plans that's many thousands of lines.

Follow up to #43/#45. Due to the verbosity and lack of schema of `observe_dashboard`, it can trigger extremely long plans, potentially several kilobytes.