### PR TITLE
ci: update default terraform version to latest

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -11,7 +11,7 @@ on:
         description: "Terraform version"
         required: false
         type: string
-        default: "1.2.9"
+        default: "latest"
 
 jobs:
   commit-validation:


### PR DESCRIPTION
## what does this PR do?

updates the default terraform version of our tftests

## Motivation

some of our stuff needs 1.3+ flavors, and i don't much like the idea of all the content repos having their own versions passed in for their tftests. 

## Testing

haven't really, but if stuff breaks in tests we should find out quickly and that would just mean that there's a breaking change in terraform, so we'd be able to override with a specific version.