### PR TITLE
feat: update sync-from-template-repo workflow to also sync the .tflint.hcl file

### DIFF
--- a/.github/workflows/terraform-observe_sync-from-template-repo.yaml
+++ b/.github/workflows/terraform-observe_sync-from-template-repo.yaml
@@ -100,6 +100,7 @@ jobs:
             find ${{ env.REPO_TEMPLATE }} \( \
             -name "Makefile" -o \
             -name ".pre-commit-config.yaml" -o \
+            -name ".tflint.hcl" -o \
             -name "LICENSE" \) \
             -type f \
             -print)"


### PR DESCRIPTION
# What does this PR do?

adds the `.tflint.hcl` to the workflow that syncs all the children app repos from their template (terraform-observe-example)

# Motivation

Will unlock custom TFlinting capabilities for all the app repos without having to manually generate PRs on all of them all the time (as we update it)

# Testing
Honestly haven't really. I think we can just try the workflow out on a child repo and carefully watch the results. 