### PR TITLE
fix: add github_token to pre-commit setup tflint step

### DIFF
--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -128,3 +128,5 @@ jobs:
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
         run: pre-commit run --color=always --show-diff-on-failure --all-files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this PR do? 

Adds github token to the "setup tflint" step of pre-commit workflow. 

# Motivation

We need that workflow to use a github token to authenticate with `tflint --init` so that we don't get [rate limited](https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting). 

For context, [here's the source](https://github.com/terraform-linters/setup-tflint#using-custom-github-token) of what i referred to to understand how we need to pass in the token. 