### PR TITLE
terraform: remove extraneous AWS credentials

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -12,15 +12,9 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
       pull-requests: write
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
-          aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}
       - uses: actions/checkout@v3
       
       - uses: actions/setup-python@v4

--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -37,7 +37,6 @@ jobs:
     needs: getDirectories
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     strategy:
       matrix:
@@ -47,11 +46,6 @@ jobs:
       # Validating submodules will fail without this (https://github.com/gruntwork-io/pre-commit/issues/42)
       OBSERVE_CUSTOMER: 0
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
-          aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Python
@@ -95,7 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: getBaseVersion
     permissions:
-      id-token: write
       contents: read
     strategy:
       fail-fast: false
@@ -103,11 +96,6 @@ jobs:
         version:
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
-          aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Python


### PR DESCRIPTION
Removes AWS credentials from places they do not belong. For Terraform modules, the only time AWS credentials should be needed is when publishing a release (to S3).

Also removes the `id-token` permission, since an ID token is only used to exchange for AWS credentials.