### PR TITLE
feat: bump terraform version for tf-account

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -17,7 +17,7 @@ on:
         description: 'Terraform version'
         required: false
         type: string
-        default: '1.2.4'
+        default: '1.5.4'
 
 jobs:
   terraform:


### PR DESCRIPTION
We've let the terraform version lag for a while, but the config-driven state management in version 1.5 is useful for tf-account.