### PR TITLE
feat: allow specifying HTTPS_PROXY, NO_PROXY, TS_TAGS

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -12,12 +12,25 @@ on:
         required: true
       TF_BACKEND_S3_REGION:
         required: true
+      TS_OAUTH_CLIENT_ID:
+        required: false
+      TS_OAUTH_SECRET:
+        required: false
     inputs:
       terraform-version:
         description: 'Terraform version'
         required: false
         type: string
         default: '1.5.4'
+      TS_TAGS:
+        required: false
+        type: string
+      HTTPS_PROXY:
+        required: false
+        type: string
+      NO_PROXY:
+        required: false
+        type: string
 
 jobs:
   terraform:
@@ -37,6 +50,15 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform-version }}
 
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        # a tailscale oauth client requires tags
+        if: inputs.TS_TAGS != ''
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: ${{ inputs.TS_TAGS }}
+
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check
@@ -50,6 +72,8 @@ jobs:
 
       - name: Terraform Init
         id: init
+        # We avoid proxying on init, otherwise the exclusion
+        # list must be extended to cover provider registries.
         run: |
           terraform init -no-color \
             -backend-config="bucket=${{ secrets.TF_BACKEND_S3_BUCKET }}" \
@@ -63,6 +87,9 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
+        env:
+          HTTPS_PROXY: ${{ inputs.HTTPS_PROXY }}
+          NO_PROXY: ${{ inputs.NO_PROXY }}
         run: |
           path='plan'
           txt_path='plan.txt'
@@ -123,4 +150,7 @@ jobs:
 
       - name: Terraform Apply
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          HTTPS_PROXY: ${{ inputs.HTTPS_PROXY }}
+          NO_PROXY: ${{ inputs.NO_PROXY }}
         run: terraform apply -auto-approve

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -22,13 +22,13 @@ on:
         required: false
         type: string
         default: '1.5.4'
-      TS_TAGS:
+      tailscale-tags:
         required: false
         type: string
-      HTTPS_PROXY:
+      https-proxy:
         required: false
         type: string
-      NO_PROXY:
+      no-proxy:
         required: false
         type: string
 
@@ -53,11 +53,11 @@ jobs:
       - name: Tailscale
         uses: tailscale/github-action@v2
         # a tailscale oauth client requires tags
-        if: inputs.TS_TAGS != ''
+        if: inputs.tailscale-tags != ''
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: ${{ inputs.TS_TAGS }}
+          tags: ${{ inputs.tailscale-tags }}
 
       - name: Terraform Format
         id: fmt
@@ -65,6 +65,9 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
+        env:
+          HTTPS_PROXY: ${{ inputs.https-proxy }}
+          NO_PROXY: ${{ inputs.no-proxy }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.sha }}
@@ -72,8 +75,9 @@ jobs:
 
       - name: Terraform Init
         id: init
-        # We avoid proxying on init, otherwise the exclusion
-        # list must be extended to cover provider registries.
+        env:
+          HTTPS_PROXY: ${{ inputs.https-proxy }}
+          NO_PROXY: ${{ inputs.no-proxy }}
         run: |
           terraform init -no-color \
             -backend-config="bucket=${{ secrets.TF_BACKEND_S3_BUCKET }}" \
@@ -88,8 +92,8 @@ jobs:
         id: plan
         if: github.event_name == 'pull_request'
         env:
-          HTTPS_PROXY: ${{ inputs.HTTPS_PROXY }}
-          NO_PROXY: ${{ inputs.NO_PROXY }}
+          HTTPS_PROXY: ${{ inputs.https-proxy }}
+          NO_PROXY: ${{ inputs.no-proxy }}
         run: |
           path='plan'
           txt_path='plan.txt'
@@ -151,6 +155,6 @@ jobs:
       - name: Terraform Apply
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
-          HTTPS_PROXY: ${{ inputs.HTTPS_PROXY }}
-          NO_PROXY: ${{ inputs.NO_PROXY }}
+          HTTPS_PROXY: ${{ inputs.https-proxy }}
+          NO_PROXY: ${{ inputs.no-proxy }}
         run: terraform apply -auto-approve

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -59,15 +59,18 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: ${{ inputs.tailscale-tags }}
 
+      - name: Config Proxy Environment Variables
+        if: inputs.https-proxy != ''
+        run: |
+          echo "HTTPS_PROXY=${{ inputs.https-proxy }}" >> "$GITHUB_ENV"
+          echo "NO_PROXY=${{ inputs.no-proxy }}" >> "$GITHUB_ENV"
+
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
-        env:
-          HTTPS_PROXY: ${{ inputs.https-proxy }}
-          NO_PROXY: ${{ inputs.no-proxy }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.sha }}
@@ -75,9 +78,6 @@ jobs:
 
       - name: Terraform Init
         id: init
-        env:
-          HTTPS_PROXY: ${{ inputs.https-proxy }}
-          NO_PROXY: ${{ inputs.no-proxy }}
         run: |
           terraform init -no-color \
             -backend-config="bucket=${{ secrets.TF_BACKEND_S3_BUCKET }}" \
@@ -91,9 +91,6 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
-        env:
-          HTTPS_PROXY: ${{ inputs.https-proxy }}
-          NO_PROXY: ${{ inputs.no-proxy }}
         run: |
           path='plan'
           txt_path='plan.txt'

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -61,9 +61,14 @@ jobs:
 
       - name: Config Proxy Environment Variables
         if: inputs.https-proxy != ''
+        # intermediate variables to avoid injection attack
+        # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          HTTPS_PROXY: ${{ inputs.https-proxy }}
+          NO_PROXY: ${{ inputs.no-proxy }}
         run: |
-          echo "HTTPS_PROXY=${{ inputs.https-proxy }}" >> "$GITHUB_ENV"
-          echo "NO_PROXY=${{ inputs.no-proxy }}" >> "$GITHUB_ENV"
+          printf "HTTPS_PROXY=%s\n" "$HTTPS_PROXY" >> "$GITHUB_ENV"
+          printf "NO_PROXY=%s\n" "$NO_PROXY" >> "$GITHUB_ENV"
 
       - name: Terraform Format
         id: fmt
@@ -151,7 +156,4 @@ jobs:
 
       - name: Terraform Apply
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        env:
-          HTTPS_PROXY: ${{ inputs.https-proxy }}
-          NO_PROXY: ${{ inputs.no-proxy }}
         run: terraform apply -auto-approve


### PR DESCRIPTION
This commit adds:

- the ability to optionally configure an OAuth tailscale client to connect to an existing tailnet
- the ability to specify HTTPS_PROXY and NO_PROXY for use in `terraform plan` and `apply`

Combining both features a user can proxy requests to the Observe API through an access node in a tailscale network.