### PR TITLE
feat: make sure release only happens on default_branch like main

### DIFF
--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -24,6 +24,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check branch
+        if: github.ref_name != github.event.repository.default_branch
+        run: |
+          echo "::error::release job must be run from the default_branch (${{ github.event.repository.default_branch }}). Found ${{ github.ref_name }}."
+          exit 1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check branch
-        if: github.ref_name != github.event.repository.default_branch
+        if: github.ref_type != 'branch' || github.ref_name != github.event.repository.default_branch
         run: |
           echo "::error::release job must be run from the default_branch (${{ github.event.repository.default_branch }}). Found ${{ github.ref_name }}."
           exit 1


### PR DESCRIPTION
# What does this PR do?

Adds a check to make sure that the `Release and Push` workflow only runs from the default branch (usually `main`), stops people from accidentally running the `Release and Push` workflow from a non-default branch. 

# Testing

I've tested on a throwaway repo with success:
- Ran the job from a non-main and it [successfully errored](https://github.com/observeinc/terraform-observe-slobsv-test2/actions/runs/5826786434) with a nice error log
- Ran the job from a main branch and it [successfully ran the job](https://github.com/observeinc/terraform-observe-slobsv-test2/actions/runs/5826769476)

Closes #86