### PR TITLE
fix: bump tflint version to pass ci tests

### DIFF
--- a/.github/workflows/terraform-observe_pre-commit.yaml
+++ b/.github/workflows/terraform-observe_pre-commit.yaml
@@ -6,7 +6,7 @@ on:
       tflint-version:
         required: false
         type: string
-        default: v0.35.0
+        default: v0.45.0
         
     secrets:
       TERRAFORM_MODULES_ROLE_ARN:


### PR DESCRIPTION
This bumps the tflint version version to `v0.45.0`.  We need this version because our observe plugin for tflint requires API version 11 and the tflint version are using only support up to version 10.

Note that I chose this version because I've seen a few other repos using this as an override.