### PR TITLE
feat: allow setting twingate-enabled

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -25,6 +25,10 @@ on:
       tailscale-tags:
         required: false
         type: string
+      twingate-enabled:
+        required: false
+        type: boolean
+        default: false
       https-proxy:
         required: false
         type: string
@@ -58,6 +62,12 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: ${{ inputs.tailscale-tags }}
+
+      - name: Twingate
+        uses: twingate/github-action@v1.1
+        if: inputs.twingate-enabled
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
 
       - name: Config Proxy Environment Variables
         if: inputs.https-proxy != ''

--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -16,6 +16,8 @@ on:
         required: false
       TS_OAUTH_SECRET:
         required: false
+      TWINGATE_SERVICE_KEY:
+        required: false
     inputs:
       terraform-version:
         description: 'Terraform version'


### PR DESCRIPTION
When twingate-enabled is set to true, a twingate client is started using a pre-defined service key for a "github_actions" service account.

No proxies are required with Twingate (unlike Tailscale) because DNS records get overridden for select endpoints. The service account is currently setup to route traffic through Twingate for cap1 DNS names {155210249240,168414722295}.cap1.observeinc.com.

Next up:
* a PR for tf-account-cap-one to switch tailscale->twingate
* a PR here to remove tailscale support