### PR TITLE
feat: repo input for repositories with changed names

### DIFF
--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -67,8 +67,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          if ${{ github.event.inputs.repo-name-slack != '' }}; then  
-            echo name=$(echo "${{ github.event.inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          if ${{ inputs.repo-name-slack != '' }}; then  
+            echo name=$(echo "${{ inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
           if ${{ inputs.repo-name-slack != '' }}; then  
-            echo name=$(echo "${{ inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+            echo name=$(echo "${{ inputs.repo-name-slack }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -14,6 +14,11 @@ on:
         type: string
         description: Number of releases to preserve in changelog. Default is 0 (regenerates all).
         default: '0'
+      repo-name-slack:
+        required: false
+        type: string
+        description: Override for renamed repositories
+        default: ''
 
 jobs:
   publish:
@@ -62,7 +67,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          if ${{ github.event.inputs.repo-name-slack != '' }}; then  
+            echo name=$(echo "${{ github.event.inputs.repo-name-slack != '' }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          else
+            echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          fi
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_PRERELEASE_SLACK_URL }}

--- a/.github/workflows/terraform-observe_prerelease.yaml
+++ b/.github/workflows/terraform-observe_prerelease.yaml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ env.SLACK_WEBHOOK_URL != '' }}
         run: |
           if ${{ github.event.inputs.repo-name-slack != '' }}; then  
-            echo name=$(echo "${{ github.event.inputs.repo-name-slack != '' }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+            echo name=$(echo "${{ github.event.inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo version=$(echo "${{ steps.changelog.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
           if ${{ inputs.repo-name-slack != '' }}; then  
-          echo name=$(echo "${{ inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          echo name=$(echo "${{ inputs.repo-name-slack }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo version=$(echo "${{ steps.changelog.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
           if ${{ github.event.inputs.repo-name-slack != '' }}; then  
-          echo name=$(echo "${{ github.event.inputs.repo-name-slack != '' }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          echo name=$(echo "${{ github.event.inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -68,8 +68,8 @@ jobs:
         if: ${{ env.SLACK_WEBHOOK_URL != '' && steps.changelog.outputs.skipped == 'false' }}
         run: |
           echo version=$(echo "${{ steps.changelog.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
-          if ${{ github.event.inputs.repo-name-slack != '' }}; then  
-          echo name=$(echo "${{ github.event.inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          if ${{ inputs.repo-name-slack != '' }}; then  
+          echo name=$(echo "${{ inputs.repo-name-slack}}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           else
             echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
           fi

--- a/.github/workflows/terraform-observe_release.yaml
+++ b/.github/workflows/terraform-observe_release.yaml
@@ -14,6 +14,11 @@ on:
         type: string
         description: Number of releases to preserve in changelog. Default is 0 (regenerates all).
         default: '0'
+      repo-name-slack:
+        required: false
+        type: string
+        description: Override for renamed repositories
+        default: ''
 
 jobs:
   bump:
@@ -63,7 +68,11 @@ jobs:
         if: ${{ env.SLACK_WEBHOOK_URL != '' && steps.changelog.outputs.skipped == 'false' }}
         run: |
           echo version=$(echo "${{ steps.changelog.outputs.tag }}" | sed 's/^v//' ) >> $GITHUB_ENV
-          echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          if ${{ github.event.inputs.repo-name-slack != '' }}; then  
+          echo name=$(echo "${{ github.event.inputs.repo-name-slack != '' }}" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          else
+            echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+          fi
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_RELEASE_SLACK_URL }}


### PR DESCRIPTION
Adds input to release workflows so repo name for slack notification can be overridden for repo renames

# Tested on terraform-observe-google repo

![image](https://github.com/observeinc/.github/assets/103078673/a38615ab-87d2-4da3-8957-e91ae32032b3)


https://github.com/observeinc/terraform-observe-google-cloud-monitoring/actions/runs/8012769868

<img width="1015" alt="image" src="https://github.com/observeinc/.github/assets/103078673/170e23a2-2f31-463b-bf64-fdd152ee2969">

<img width="1337" alt="image" src="https://github.com/observeinc/.github/assets/103078673/225a8c92-9ab2-4555-af77-b16f7d7aa4ed">

<img width="1289" alt="image" src="https://github.com/observeinc/.github/assets/103078673/ef8489ac-f926-4839-8f01-3fbf78404f26">

# If I run without input it behaves the way it always did
<img width="1494" alt="image" src="https://github.com/observeinc/.github/assets/103078673/58264f07-896f-4d90-85e3-63f073e572d8">
