### PR TITLE
fix: OB-28708 add round robin

### DIFF
--- a/.github/scripts/main.py
+++ b/.github/scripts/main.py
@@ -1,0 +1,100 @@
+import os
+import glob
+
+# TO TEST THIS LOCALLY
+# export GITHUB_OUTPUT=testyone
+# export GITHUB_ENV=testytwo
+# export TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER_LIST="['123578675166', '128872978242']"
+# export TEST_DIRECTORY=~/content_eng/k8s/terraform-observe-kubernetes
+# python main.py
+# should output testyone file with value like:
+# directories_with_customerID=["/Users/arthur/content_eng/k8s/terraform-observe-kubernetes/tftests/default_XXXXXX_123578675166", "/Users/arthur/content_eng/k8s/terraform-observe-kubernetes/tftests/gcp_XXXXXX_128872978242", "/Users/arthur/content_eng/k8s/terraform-observe-kubernetes/tftests/min_provider_XXXXXX_123578675166", "/Users/arthur/content_eng/k8s/terraform-observe-kubernetes/tftests/aws_XXXXXX_128872978242", "/Users/arthur/content_eng/k8s/terraform-observe-kubernetes/tftests/all_options_XXXXXX_123578675166"]
+
+
+def list_subdirectories(parent_dir, pattern):
+    """Returns a list of subdirectories under parent_dir using pattern"""
+    # Create the glob pattern to match subdirectories
+    glob_pattern = os.path.join(parent_dir, pattern)
+    # Use glob to find subdirectories matching the pattern
+    subdirectories = glob.glob(glob_pattern)
+    # Filter out files from the list
+    subdirectories = [
+        directory for directory in subdirectories if os.path.isdir(directory)
+    ]
+
+    return subdirectories
+
+
+def pick_my_env(ENVS, DIRS):
+    """Adds a customerID for each script to accomplish round robin"""
+    envs_count = len(ENVS)
+    # use this for validation purposes
+    envs_list = []
+
+    env_index = 0
+    for dir in DIRS:
+        concat_string = f"{dir}_XXXXXX_{ENVS[env_index]}"
+        concat_string = concat_string.replace(" ", "").replace("'", "")
+        envs_list.append(concat_string)
+        print("-----------------")
+        print("dir = ", dir)
+
+        print("env = ", ENVS[env_index])
+        env_index += 1
+
+        if env_index > envs_count - 1:
+            env_index = 0
+        print("-----------------")
+
+    # need this form to write to file
+    envs_list_range = f"""[{", ".join(f'"{item}"' for item in envs_list)}]"""
+    return envs_list, envs_list_range
+
+
+def split_string_into_dir_and_customer(string_to_split, delimiter="_XXXXXX_"):
+    split_list = string_to_split.split(delimiter)
+    if len(split_list) != 2:
+        raise ValueError(f"Bad string value: {string_to_split}")
+
+    # write to Github Actions GITHUB_ENV file
+    with open(os.environ["GITHUB_ENV"], "a") as ge:
+        print(f"TEST_DIR={split_list[0]}", file=ge)
+        print(f"CUST_NUMBER={split_list[1]}", file=ge)
+
+    return None
+
+
+if __name__ == "__main__":
+
+    # Github actions environment variable
+    GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT")
+    GITHUB_ENV = os.getenv("GITHUB_ENV")
+    # Comma separated list of customer ids for staging environment that are used to runs tftests - provided as a secret
+    TEST_CUSTOMER_IDS = (
+        os.getenv("TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER_LIST")
+        .replace("[", "")
+        .replace("]", "")
+    )
+
+    # Split back into python list
+    ENVS = TEST_CUSTOMER_IDS.split(",")
+
+    # Example usage:
+    parent_directory = os.getenv("TEST_DIRECTORY") or os.getcwd()
+    pattern = "tftests/*"  # Match all directories
+
+    subdirectories = list_subdirectories(parent_directory, pattern)
+    envs_list, envs_list_range = pick_my_env(ENVS, subdirectories)
+
+    # write to Github Actions GITHUB_OUTPUT file
+    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+        print(f"directories_with_customerID={envs_list_range}", file=fh)
+
+    # Print out for validation
+    i = 0
+    for dir in envs_list:
+        print(dir)
+        split_str = dir.split("_XXXXXX_")
+        print(split_str[0])
+        print(split_str[1])
+        i += 1

--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: "latest"
+      script_branch:
+        description: "Branch of python script"
+        required: false
+        type: string
+        default: "main"
 
 jobs:
   commit-validation:
@@ -27,33 +32,57 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build matrix
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: download python script
         id: matrix
-        shell: bash
         run: |
-          DIRS="$(find . -path "*tftests/*" ! -path "*.terraform*" -type d )"
-          [[ ${#DIRS} > 0 ]] && echo "directories=[\"${DIRS//$'\n'/\",\"}\"]" >> "$GITHUB_OUTPUT" || echo "directories=[]" >> "$GITHUB_OUTPUT"
+          curl -O https://raw.githubusercontent.com/observeinc/.github/${{ inputs.script_branch }}/.github/scripts/main.py
+          # script creates output directories_with_customerID
+          python3 main.py
+        env:
+          TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER_LIST: ${{ vars.TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER_LIST }}
+
     outputs:
-      directories: ${{ steps.matrix.outputs.directories }}
+      directories_with_customerID: ${{ steps.matrix.outputs.directories_with_customerID }}
 
   terraform-test-apply:
     needs: get-test-directories
-    if: ${{ needs.get-test-directories.outputs.directories != '[]' && needs.get-test-directories.outputs.directories != '' }}
+    if: ${{ needs.get-test-directories.outputs.directories_with_customerID != '' }}
     name: Test Terraform Module
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
-        directory: ${{ fromJson(needs.get-test-directories.outputs.directories) }}
+        directories_with_customerID: ${{ fromJson(needs.get-test-directories.outputs.directories_with_customerID) }}
     steps:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ inputs.terraform-version }}
       - uses: actions/checkout@v4
+
+      
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: split ${{ matrix.directories_with_customerID }}
+        id: matrix
+        run: |
+          curl -O https://raw.githubusercontent.com/observeinc/.github/${{ inputs.script_branch }}/.github/scripts/main.py
+       
+          python3 -c 'from main import split_string_into_dir_and_customer; split_string_into_dir_and_customer("${{ matrix.directories_with_customerID }}");'
+      
       - name: make test
-        run: make test "${{ matrix.directory }}"
+        run: |
+          make test "${{ env.TEST_DIR }}"
+
         env:
-          OBSERVE_CUSTOMER: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_CUSTOMER }}
+          OBSERVE_CUSTOMER: ${{ env.CUST_NUMBER }}
           OBSERVE_DOMAIN: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_DOMAIN }}
           OBSERVE_USER_EMAIL: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_EMAIL }}
           OBSERVE_USER_PASSWORD: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ typings/
 
 # TernJS port file
 .tern-port
+
+# Test generated file
+testy*
+/.github/scripts/__pycache__


### PR DESCRIPTION
Creates a python script that will associate each test directory with a customer id that is passed in as a comma separated list via GHA secret.  Assumes that all environments are in staging and all have same content reviewer username and password.
<img width="876" alt="image" src="https://github.com/observeinc/.github/assets/103078673/8eb1b12b-74fa-42de-b890-9a75e246e3f2">

3 of 4 existing variables stay the same and only array of customer ids is new.
<img width="968" alt="image" src="https://github.com/observeinc/.github/assets/103078673/7f016c53-3178-4aa1-a574-9b0686977996">

