### PR TITLE
feat: synchronize github secrets to secretsmanager

### DIFF
--- a/.github/workflows/tf-account.yaml
+++ b/.github/workflows/tf-account.yaml
@@ -77,6 +77,20 @@ jobs:
           role-session-name: ${{ github.sha }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Synchronize secrets
+        env:
+          SECRETS: ${{ toJSON(secrets) }}
+        shell: bash
+        run: |
+          LOCAL=`echo "$SECRETS" | jq 'with_entries(select(.key | startswith("X_")))'`
+          REMOTE=`aws secretsmanager get-secret-value --secret-id ${{ github.event.repository.name }} | jq -r .SecretString`
+          FILTERED=`echo ${REMOTE} | jq 'with_entries(select(.key | startswith("X_") | not))'`
+          MERGED=`echo ${LOCAL} ${REMOTE} | jq -s add`
+          if [[ "$MERGED" != "$REMOTE" ]]
+          then
+            aws secretsmanager put-secret-value --secret-id ${{ github.event.repository.name }} --secret-string="$MERGED"
+          fi
+
       - name: Terraform Init
         id: init
         run: |


### PR DESCRIPTION
It is more convenient to manage secrets in github than to interact with AWS secretsmanager. Unfortunately, doing so naively would make it impossible for an operator to run terraform manually if a complex state operation were to be necessary. As a workaround, we can ensure that secrets with prefix `X_` are synchronized to secretsmanager on every workflow run.