### PR TITLE
fix: reduce parallelism in terraform-observe_scheduler.yaml

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         directories_with_customerID: ${{ fromJson(needs.get-test-directories.outputs.directories_with_customerID) }}
     steps:


### PR DESCRIPTION
See https://observe.atlassian.net/browse/OB-28707

Reduces load on staging api server by reducing parallel terraforming against it to 3 