### PR TITLE
feat: add retry for terraform scheduled tests

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -78,15 +78,16 @@ jobs:
           python3 -c 'from main import split_string_into_dir_and_customer; split_string_into_dir_and_customer("${{ matrix.directories_with_customerID }}");'
       
       - name: make test
-        run: |
-          make test "${{ env.TEST_DIR }}"
-
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: make test "${{ env.TEST_DIR }}"
         env:
           OBSERVE_CUSTOMER: ${{ env.CUST_NUMBER }}
           OBSERVE_DOMAIN: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_DOMAIN }}
           OBSERVE_USER_EMAIL: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_EMAIL }}
           OBSERVE_USER_PASSWORD: ${{ secrets.TERRAFORM_MODULES_TEST_OBSERVE_USER_PASSWORD }}
-
           GITHUB_WORKSPACE: ${{ github.workspace }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Updates scheduled tests to include retries for failing tests
- Tested in `terraform-observe-host` which always had failing tests and seems to work well

See: 

- https://github.com/observeinc/terraform-observe-host/actions/runs/11582343232/job/32245166871#annotation:6:3766
- https://observe.atlassian.net/browse/OB-28707?focusedCommentId=210284
