### PR TITLE
fix: skip commit-validation on non-pull_request events

### DIFF
--- a/.github/workflows/terraform-observe_scheduler.yaml
+++ b/.github/workflows/terraform-observe_scheduler.yaml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   commit-validation:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/shared_commit-validation.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

- `terraform-observe_scheduler.yaml` calls `shared_commit-validation.yaml` unconditionally, but both jobs inside that workflow are gated on `github.event_name == 'pull_request'`
- On push-to-main, all jobs in the called workflow are skipped; GitHub treats a `workflow_call` job whose called workflow has **all-skipped jobs** as `conclusion: failure`, causing every post-merge CI Tests run to fail with a red X
- This has been happening on all terraform-observe connection repos since at least September 2025
- Fix: add `if: github.event_name == 'pull_request'` to the `commit-validation` caller so the job itself is skipped on push events (GitHub propagates `skipped` correctly, not `failure`)

## Test plan

- [x] Verify CI Tests run passes on this PR (pull_request event — commit-validation should run as normal)
- [ ] After merge, verify the next push-to-main CI Tests run no longer shows `conclusion: failure`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)